### PR TITLE
Add `-format` flag and `-format csv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,22 @@ $ netstat -i | head -5 | mktable -s ' +'
 
 ## Flags
 
-| Flag               | Default          | Description                                     |
-| ------------------ | ---------------- | ----------------------------------------------- |
-| `-s`               | `[ \t]*\t[ \t]*` | Regexp used to set the delimiter                |
-| `-no-headers`      | `false`          | Skip printing headers                           |
-| `-r` / `-reformat` | `false`          | Reformat existing markdown table                |
-| `-a`               | none             | Sets the alignment. See [Alignment](#alignment) |
+| Flag               | Default          | Description                                                    |
+| ------------------ | ---------------- | -------------------------------------------------------------- |
+| `-s`               | `[ \t]*\t[ \t]*` | Regexp used to set the delimiter                               |
+| `-no-headers`      | `false`          | Skip printing headers                                          |
+| `-r` / `-reformat` | `false`          | Reformat existing markdown table. Alias for -format mk         |
+| `-a`               | none             | Sets the alignment. See [Alignment](#alignment)                |
+| `-f`               | `regexp`         | Sets the input format. See [Formats](#format) for more details |
+
+## Formats
+
+| Format            | Description                                         |
+| ----------------- | --------------------------------------------------- |
+| `re` / `regexp`   | Regular Expression Delimiter                        |
+| `csv`             | Comma Separated List                                |
+| `mk` / `markdown` | Consume an existing markdown table for reformatting |
+
 
 ## Alignment
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ netstat -i | head -5 | mktable -s ' +'
 | ------------------ | ---------------- | -------------------------------------------------------------- |
 | `-s`               | `[ \t]*\t[ \t]*` | Regexp used to set the delimiter                               |
 | `-no-headers`      | `false`          | Skip printing headers                                          |
-| `-r` / `-reformat` | `false`          | Reformat existing markdown table. Alias for -format mk         |
+| `-r` / `-reformat` | `false`          | Reformat existing markdown table. Alias for `-format mk`       |
 | `-a`               | none             | Sets the alignment. See [Alignment](#alignment)                |
 | `-f`               | `regexp`         | Sets the input format. See [Formats](#format) for more details |
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ netstat -i | head -5 | mktable -s ' +'
 | `-no-headers`      | `false`          | Skip printing headers                                          |
 | `-r` / `-reformat` | `false`          | Reformat existing markdown table. Alias for `-format mk`       |
 | `-a`               | none             | Sets the alignment. See [Alignment](#alignment)                |
-| `-f`               | `regexp`         | Sets the input format. See [Formats](#format) for more details |
+| `-f` / `-format`   | `regexp`         | Sets the input format. See [Formats](#format) for more details |
 
 ## Formats
 

--- a/formatvalue.go
+++ b/formatvalue.go
@@ -1,0 +1,33 @@
+package main
+
+import "github.com/keyneston/mktable/table"
+
+type FormatValue struct {
+	format table.Format
+}
+
+func (fv *FormatValue) Get() interface{} {
+	return fv.GetFormat()
+}
+
+func (fv *FormatValue) GetFormat() table.Format {
+	if fv.format == "" {
+		return table.FormatRE
+	}
+
+	return fv.format
+}
+
+func (fv *FormatValue) String() string {
+	return string(fv.format)
+}
+
+func (fv *FormatValue) Set(in string) error {
+	f, err := table.ParseFormat(in)
+	if err != nil {
+		return err
+	}
+
+	fv.format = f
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/keyneston/mktable/table"
 )
@@ -14,6 +16,7 @@ type Config struct {
 	Seperator   string
 	MaxPadding  int
 	Reformat    bool
+	Format      FormatValue
 
 	Alignments ParseAlignments
 
@@ -21,12 +24,15 @@ type Config struct {
 }
 
 func (c *Config) Register(f *flag.FlagSet) *Config {
+	allFormats := strings.Join(table.AllFormats(), ",")
+
 	c.fset = f
 	c.fset.BoolVar(&c.SkipHeaders, "no-header", false, "Skip Setting Headers")
 	c.fset.StringVar(&c.Seperator, "s", `[ \t]*\t[ \t]*`, "Regexp of Delimiter to Build Table on")
 	c.fset.IntVar(&c.MaxPadding, "max-padding", -1, "Maximum units of padding. Set to a negative number for unlimited")
 	c.fset.BoolVar(&c.Reformat, "r", false, "Read in markdown table and reformat")
 	c.fset.BoolVar(&c.Reformat, "reformat", false, "Alias for -r")
+	c.fset.Var(&c.Format, "f", fmt.Sprintf("Set the format. Available formats: %v", allFormats))
 	c.fset.Var(&c.Alignments, "a", "Set column alignments; Can be called multiple times and/or comma separated. Arrow indicates direction '<' left, '>' right, '=' center; Columns are zero indexed; e.g. -a '0<,1>,2='")
 
 	return c
@@ -47,13 +53,18 @@ func main() {
 		log.Fatalf("Error: %v", err)
 	}
 
-	tb := table.NewTable(regexp.MustCompile(c.Seperator))
+	tableConfig := table.TableConfig{
+		MaxPadding:  c.MaxPadding,
+		SkipHeaders: c.SkipHeaders,
+		Alignments:  c.Alignments.alignments,
+		Seperator:   regexp.MustCompile(c.Seperator),
+		Format:      c.Format.GetFormat(),
+	}
+	if c.Reformat {
+		tableConfig.Format = table.FormatMK
+	}
 
-	tb.MaxPadding = c.MaxPadding
-	tb.SkipHeaders = c.SkipHeaders
-	tb.Reformat = c.Reformat
-	tb.Alignments = c.Alignments.alignments
-
+	tb := table.NewTable(tableConfig)
 	tb.Read(os.Stdin)
 	tb.Write(os.Stdout)
 }

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func (c *Config) Register(f *flag.FlagSet) *Config {
 	c.fset.BoolVar(&c.Reformat, "r", false, "Read in markdown table and reformat")
 	c.fset.BoolVar(&c.Reformat, "reformat", false, "Alias for -r")
 	c.fset.Var(&c.Format, "f", fmt.Sprintf("Set the format. Available formats: %v", allFormats))
+	c.fset.Var(&c.Format, "format", "Alias for -f")
 	c.fset.Var(&c.Alignments, "a", "Set column alignments; Can be called multiple times and/or comma separated. Arrow indicates direction '<' left, '>' right, '=' center; Columns are zero indexed; e.g. -a '0<,1>,2='")
 
 	return c

--- a/table/config.go
+++ b/table/config.go
@@ -1,0 +1,23 @@
+package table
+
+import "regexp"
+
+type TableConfig struct {
+	MaxPadding  int
+	SkipHeaders bool
+	Format      Format
+	Alignments  map[int]Alignment
+	Seperator   *regexp.Regexp
+	NewLine     NewLine
+}
+
+func NewConfig() TableConfig {
+	return TableConfig{}
+}
+
+func (t TableConfig) SetSeperator(in string) TableConfig {
+	t.Seperator = regexp.MustCompile(in)
+	t.Format = FormatRE
+
+	return t
+}

--- a/table/config.go
+++ b/table/config.go
@@ -21,3 +21,8 @@ func (t TableConfig) SetSeperator(in string) TableConfig {
 
 	return t
 }
+
+func (t TableConfig) SetFormat(format Format) TableConfig {
+	t.Format = format
+	return t
+}

--- a/table/format.go
+++ b/table/format.go
@@ -1,0 +1,36 @@
+package table
+
+import "fmt"
+
+type Format string
+
+const (
+	FormatRE      Format = "regexp"
+	FormatCSV     Format = "csv"
+	FormatTSV     Format = "tsv"
+	FormatMK      Format = "mk"
+	FormatUnknown Format = "unknown"
+)
+
+func AllFormats() []string {
+	return []string{
+		string(FormatRE),
+		string(FormatMK),
+		string(FormatCSV),
+	}
+}
+
+func ParseFormat(in string) (Format, error) {
+	switch in {
+	case "re", "regexp", "regex":
+		return FormatRE, nil
+	case "csv":
+		return FormatCSV, nil
+		//	case "tsv":
+		//		return FormatTSV, nil
+	case "mk", "markdown":
+		return FormatMK, nil
+	default:
+		return FormatUnknown, fmt.Errorf("Unknown format %q", in)
+	}
+}

--- a/table/format.go
+++ b/table/format.go
@@ -1,6 +1,9 @@
 package table
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type Format string
 
@@ -21,7 +24,7 @@ func AllFormats() []string {
 }
 
 func ParseFormat(in string) (Format, error) {
-	switch in {
+	switch strings.ToLower(in) {
 	case "re", "regexp", "regex":
 		return FormatRE, nil
 	case "csv":

--- a/table/format_test.go
+++ b/table/format_test.go
@@ -1,0 +1,1 @@
+package table

--- a/table/read_csv.go
+++ b/table/read_csv.go
@@ -1,0 +1,14 @@
+package table
+
+import (
+	"encoding/csv"
+	"io"
+)
+
+func (t *Table) readFormatCSV(r io.Reader) error {
+	reader := csv.NewReader(r)
+
+	var err error
+	t.data, err = reader.ReadAll()
+	return err
+}

--- a/table/read_csv_test.go
+++ b/table/read_csv_test.go
@@ -1,0 +1,44 @@
+package table
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestReadFormatCSV(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    string
+		expected [][]string
+	}
+
+	cases := []testCase{
+		{
+			name: "basic", input: "a\nb\nc\n",
+			expected: [][]string{{"a"}, {"b"}, {"c"}},
+		},
+		{
+			name: "multi-column", input: "a,1\nb,2\nc,3\n",
+			expected: [][]string{{"a", "1"}, {"b", "2"}, {"c", "3"}},
+		},
+		{
+			name: "quotations", input: "a,\",\"\nb,2\nc,3\n",
+			expected: [][]string{{"a", ","}, {"b", "2"}, {"c", "3"}},
+		},
+	}
+
+	for _, c := range cases {
+		tb := NewTable(NewConfig().SetFormat(FormatCSV))
+		if err := tb.Read(bytes.NewBufferString(c.input)); err != nil {
+			t.Errorf("Error doing read: %v", err)
+			continue
+		}
+
+		if diff := deep.Equal(c.expected, tb.data); diff != nil {
+			t.Errorf("Table.Read(%q) =\n%v", c.name, strings.Join(diff, "\n"))
+		}
+	}
+}

--- a/table/read_mk.go
+++ b/table/read_mk.go
@@ -1,0 +1,79 @@
+package table
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+)
+
+func (t *Table) readFormatMK(r io.Reader) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		start := 0
+		for i := range data {
+			switch data[i] {
+			case '\n':
+				token := bytes.TrimSpace(data[start:i])
+				if len(token) > 0 {
+					return i, token, nil
+				}
+
+				return i + 1, []byte{'\n'}, nil
+			case '|':
+				if i > 0 && data[i-1] == '\\' {
+					continue
+				}
+				if i == 0 {
+					start = i + 1
+					continue
+				}
+
+				token := bytes.TrimSpace(data[start:i])
+				return i + 1, token, nil
+			}
+		}
+
+		return 0, nil, nil
+	})
+
+	current := []string{}
+	alignments := map[int]Alignment{}
+	isHeader := false
+	column := 0
+
+	for scanner.Scan() {
+		token := scanner.Text()
+
+		if token == "\n" {
+			if isHeader {
+				t.Alignments = alignments
+			} else {
+				t.data = append(t.data, current)
+			}
+
+			alignments = map[int]Alignment{}
+			column = 0
+			current = nil
+			isHeader = false
+			continue
+		}
+
+		// Check if it is likely part of a header row, by removing all header
+		// row chars and seeing if we have nothing left
+		if len(strings.Trim(token, ":-")) == 0 {
+			isHeader = true
+			alignments[column] = parseAlignmentHeader(token)
+		}
+
+		current = append(current, token)
+
+		column++
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	return nil
+}

--- a/table/read_mk_test.go
+++ b/table/read_mk_test.go
@@ -1,0 +1,54 @@
+package table
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestReadFormatMK(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    string
+		expected [][]string
+	}
+
+	cases := []testCase{
+		{
+			name: "basic", input: "| a | b | c |\n",
+			expected: [][]string{{"a", "b", "c"}},
+		},
+		{
+			name: "multiline", input: "| a | b | c |\n| --- | ---| ---|\n|1 | 2|3|\n",
+			expected: [][]string{{"a", "b", "c"}, {"1", "2", "3"}},
+		},
+		{
+			name: "trailing space", input: "| a | \n| --- |\n|1 |\n",
+			expected: [][]string{{"a"}, {"1"}},
+		},
+		{
+			name: "header", input: "| --- | --- | --- |\n",
+			expected: nil,
+		},
+		{
+			name: "trailing pipe", input: "| a | b | \\| |\n",
+			expected: [][]string{{"a", "b", `\|`}},
+		},
+	}
+
+	for _, c := range cases {
+		tb := NewTable(TableConfig{
+			Format: FormatMK,
+		})
+		if err := tb.Read(bytes.NewBufferString(c.input)); err != nil {
+			t.Errorf("Error doing read: %v", err)
+			continue
+		}
+
+		if diff := deep.Equal(c.expected, tb.data); diff != nil {
+			t.Errorf("Table.Read(%q) =\n%v", c.name, strings.Join(diff, "\n"))
+		}
+	}
+}

--- a/table/read_re.go
+++ b/table/read_re.go
@@ -1,0 +1,36 @@
+package table
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+)
+
+func (t *Table) readFormatRE(r io.Reader) error {
+	reader := bufio.NewReader(r)
+	for {
+		line, err := reader.ReadSlice(byte(t.NewLine))
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		if line == nil {
+			return nil
+		}
+
+		line = bytes.TrimSpace(line)
+		if len(line) < 1 {
+			continue
+		}
+
+		res := t.Seperator.Split(string(line), -1)
+		for i := range res {
+			res[i] = prepareContent(res[i])
+		}
+		t.data = append(t.data, res)
+
+	}
+}

--- a/table/read_re_test.go
+++ b/table/read_re_test.go
@@ -1,0 +1,41 @@
+package table
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestReadFormatRE(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    string
+		sep      string
+		expected [][]string
+	}
+
+	cases := []testCase{
+		{name: "basic", input: "a\nb\nc\n",
+			sep:      `\t+`,
+			expected: [][]string{{"a"}, {"b"}, {"c"}},
+		},
+		{name: "multi-column", input: "a\t1\nb\t2\nc\t3\n",
+			sep:      `\t+`,
+			expected: [][]string{{"a", "1"}, {"b", "2"}, {"c", "3"}},
+		},
+	}
+
+	for _, c := range cases {
+		tb := NewTable(NewConfig().SetSeperator(c.sep))
+		if err := tb.Read(bytes.NewBufferString(c.input)); err != nil {
+			t.Errorf("Error doing read: %v", err)
+			continue
+		}
+
+		if diff := deep.Equal(c.expected, tb.data); diff != nil {
+			t.Errorf("Table.Read(%q) =\n%v", c.name, strings.Join(diff, "\n"))
+		}
+	}
+}

--- a/table/table.go
+++ b/table/table.go
@@ -37,6 +37,8 @@ func (t *Table) Read(r io.Reader) error {
 		return t.readFormatMK(r)
 	case FormatRE:
 		return t.readFormatRE(r)
+	case FormatCSV:
+		return t.readFormatCSV(r)
 	default:
 		return fmt.Errorf("Unable to read format: %q", string(t.Format))
 	}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -3,14 +3,13 @@ package table
 import (
 	"bytes"
 	"fmt"
-	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
 )
 
-func TestTable(t *testing.T) {
+func TestReadRE(t *testing.T) {
 	type testCase struct {
 		name     string
 		input    string
@@ -23,11 +22,18 @@ func TestTable(t *testing.T) {
 			sep:      `\t+`,
 			expected: [][]string{{"a"}, {"b"}, {"c"}},
 		},
+		{name: "multi-column", input: "a\t1\nb\t2\nc\t3\n",
+			sep:      `\t+`,
+			expected: [][]string{{"a", "1"}, {"b", "2"}, {"c", "3"}},
+		},
 	}
 
 	for _, c := range cases {
-		tb := NewTable(regexp.MustCompile(c.sep))
-		tb.Read(bytes.NewBufferString(c.input))
+		tb := NewTable(NewConfig().SetSeperator(c.sep))
+		if err := tb.Read(bytes.NewBufferString(c.input)); err != nil {
+			t.Errorf("Error doing read: %v", err)
+			continue
+		}
 
 		if diff := deep.Equal(c.expected, tb.data); diff != nil {
 			t.Errorf("Table.Read(%q) =\n%v", c.name, strings.Join(diff, "\n"))
@@ -35,7 +41,7 @@ func TestTable(t *testing.T) {
 	}
 }
 
-func TestReadReformat(t *testing.T) {
+func TestReadFormatMK(t *testing.T) {
 	type testCase struct {
 		name     string
 		input    string
@@ -66,9 +72,13 @@ func TestReadReformat(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tb := NewTable(regexp.MustCompile(`\t`))
-		tb.Reformat = true
-		tb.Read(bytes.NewBufferString(c.input))
+		tb := NewTable(TableConfig{
+			Format: FormatMK,
+		})
+		if err := tb.Read(bytes.NewBufferString(c.input)); err != nil {
+			t.Errorf("Error doing read: %v", err)
+			continue
+		}
 
 		if diff := deep.Equal(c.expected, tb.data); diff != nil {
 			t.Errorf("Table.Read(%q) =\n%v", c.name, strings.Join(diff, "\n"))
@@ -76,7 +86,7 @@ func TestReadReformat(t *testing.T) {
 	}
 }
 
-func TestLongestRow(t *testing.T) {
+func TestFindColumnCount(t *testing.T) {
 	type testCase struct {
 		name     string
 		input    string
@@ -91,11 +101,15 @@ func TestLongestRow(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tb := NewTable(regexp.MustCompile(c.sep))
-		tb.Read(bytes.NewBufferString(c.input))
+		tb := NewTable(NewConfig().SetSeperator(c.sep))
+		if err := tb.Read(bytes.NewBufferString(c.input)); err != nil {
+			t.Errorf("Error doing read: %v", err)
+			continue
+		}
 
-		if c.expected != tb.longestLine() {
-			t.Errorf("tb[%q].longestLine() = %d; want %d", c.name, tb.longestLine(), c.expected)
+		tb.findColumnCount()
+		if c.expected != tb.columnCount {
+			t.Errorf("tb[%q].columnCount = %d; want %d", c.name, tb.columnCount, c.expected)
 		}
 	}
 }
@@ -105,24 +119,25 @@ func TestPrint(t *testing.T) {
 		name     string
 		input    string
 		sep      string
-		expected int
+		expected string
 	}
 
 	cases := []testCase{
-		{name: "basic", input: "a\nb\nc\n", sep: `\t+`, expected: 1},
-		{name: "differing", input: "a\te\nb\nc\n", sep: `\t+`, expected: 2},
-		{name: "snake", input: "a\te\nb\tab\tabc\nc\n", sep: `\t+`, expected: 3},
+		{name: "basic", input: "a\nb\nc\n", sep: `\t+`, expected: ""},
+		{name: "differing", input: "a\te\nb\nc\n", sep: `\t+`, expected: ""},
+		{name: "snake", input: "a\te\nb\tab\tabc\nc\n", sep: `\t+`, expected: ""},
 	}
 
 	for _, c := range cases {
 		buf := &bytes.Buffer{}
-		tb := NewTable(regexp.MustCompile(c.sep))
-		tb.Read(bytes.NewBufferString(c.input))
+		tb := NewTable(NewConfig().SetSeperator(c.sep))
+		if err := tb.Read(bytes.NewBufferString(c.input)); err != nil {
+			t.Errorf("Error doing read: %v", err)
+			continue
+		}
 		tb.Write(buf)
 		fmt.Fprintln(buf, "")
 
-		if c.expected != tb.longestLine() {
-			t.Errorf("tb[%q].longestLine() = %d; want %d", c.name, tb.longestLine(), c.expected)
-		}
+		// TODO add expected and actually test it
 	}
 }

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -3,88 +3,8 @@ package table
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"testing"
-
-	"github.com/go-test/deep"
 )
-
-func TestReadRE(t *testing.T) {
-	type testCase struct {
-		name     string
-		input    string
-		sep      string
-		expected [][]string
-	}
-
-	cases := []testCase{
-		{name: "basic", input: "a\nb\nc\n",
-			sep:      `\t+`,
-			expected: [][]string{{"a"}, {"b"}, {"c"}},
-		},
-		{name: "multi-column", input: "a\t1\nb\t2\nc\t3\n",
-			sep:      `\t+`,
-			expected: [][]string{{"a", "1"}, {"b", "2"}, {"c", "3"}},
-		},
-	}
-
-	for _, c := range cases {
-		tb := NewTable(NewConfig().SetSeperator(c.sep))
-		if err := tb.Read(bytes.NewBufferString(c.input)); err != nil {
-			t.Errorf("Error doing read: %v", err)
-			continue
-		}
-
-		if diff := deep.Equal(c.expected, tb.data); diff != nil {
-			t.Errorf("Table.Read(%q) =\n%v", c.name, strings.Join(diff, "\n"))
-		}
-	}
-}
-
-func TestReadFormatMK(t *testing.T) {
-	type testCase struct {
-		name     string
-		input    string
-		expected [][]string
-	}
-
-	cases := []testCase{
-		{
-			name: "basic", input: "| a | b | c |\n",
-			expected: [][]string{{"a", "b", "c"}},
-		},
-		{
-			name: "multiline", input: "| a | b | c |\n| --- | ---| ---|\n|1 | 2|3|\n",
-			expected: [][]string{{"a", "b", "c"}, {"1", "2", "3"}},
-		},
-		{
-			name: "trailing space", input: "| a | \n| --- |\n|1 |\n",
-			expected: [][]string{{"a"}, {"1"}},
-		},
-		{
-			name: "header", input: "| --- | --- | --- |\n",
-			expected: nil,
-		},
-		{
-			name: "trailing pipe", input: "| a | b | \\| |\n",
-			expected: [][]string{{"a", "b", `\|`}},
-		},
-	}
-
-	for _, c := range cases {
-		tb := NewTable(TableConfig{
-			Format: FormatMK,
-		})
-		if err := tb.Read(bytes.NewBufferString(c.input)); err != nil {
-			t.Errorf("Error doing read: %v", err)
-			continue
-		}
-
-		if diff := deep.Equal(c.expected, tb.data); diff != nil {
-			t.Errorf("Table.Read(%q) =\n%v", c.name, strings.Join(diff, "\n"))
-		}
-	}
-}
 
 func TestFindColumnCount(t *testing.T) {
 	type testCase struct {


### PR DESCRIPTION
This change adds native CSV support. Additionally it adds a `-f`/`-format` flag which is used to specify the format.

Fixes #4 